### PR TITLE
[80] 時間が正しく表示されない問題

### DIFF
--- a/chatapp/src/components/ChatCard.vue
+++ b/chatapp/src/components/ChatCard.vue
@@ -28,12 +28,14 @@ const importanceClass = computed(() => {
 })
 
 // 日付を見やすい形式に変換
-const formattedDate = new Date(props.chat.date).toLocaleString("ja-JP", {
-  month: "numeric",
-  day: "numeric",
-  hour: "2-digit",
-  minute: "2-digit"
-});
+const formattedDate = computed(() => {
+  return new Date(props.chat.date).toLocaleString("ja-JP", {
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+})
 </script>
 
 <template>


### PR DESCRIPTION
・ChatCard.vueで時間をフォーマットするときにcomputedをつかうように